### PR TITLE
feat: add rule no lower case in jsx tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ In your `.eslintrc.json` file :
 | mutation-decorator-return-type-mismatch | recommended   | Ensure GraphQL @Mutation(...) decorator is consistent with method return type |
 | no-async-in-foreach                     | recommended   | Ensure that we don't use async callbacks in foreach loops                     |
 | redux-saga-no-sequential-actions        | recommended   | Prevent dispatching Redux Saga actions sequentially                           |
-
+| forbid-lower-case-jsx-tags          | recommended   | Ensure all JSX tags are not in lower case          |
 # Contribute
 
 - Create a new branch and PR: https://github.com/hokla-org/eslint-plugin-custom-rules/compare

--- a/lib/rules/forbid-lowercase-jsx-tags.ts
+++ b/lib/rules/forbid-lowercase-jsx-tags.ts
@@ -1,0 +1,56 @@
+import {
+  AST_NODE_TYPES,
+  ESLintUtils,
+  TSESTree,
+} from "@typescript-eslint/utils";
+
+type MessageIds = "forbid-lowercase-jsx-tags";
+
+type Options = [];
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) => `https://hokla.com/rule/${name}`
+);
+
+// Trying to follow example from this blog :
+// https://ryankubik.com/blog/eslint-internal-state#Building-More-Complex-ESLint-Rules
+// https://astexplorer.net/#/gist/1ff99fca3f85c2e7676ac041a88d7b53/179cf88e3a77c133741d9f96f0dc982b9f11ce4d
+
+type NodeWithBody = TSESTree.Node & {
+  body: TSESTree.BlockStatement;
+};
+
+export const rule = createRule<Options, MessageIds>({
+  name: "forbid-lowercase-jsx-tags",
+  defaultOptions: [],
+  create(context) {
+    return {
+      ["JSXOpeningElement > JSXIdentifier"](
+        node: TSESTree.JSXIdentifier
+      ) {
+        const lowercaseRegex = /[a-z]/u;
+        
+        if (lowercaseRegex.test(node.name.charAt(0))) {
+          return context.report({
+            messageId: 'forbid-lowercase-jsx-tags',
+            node: node,
+          });
+        }
+      },
+    };
+  },
+  meta: {
+    docs: {
+      recommended: "error",
+      description:
+        "To be used in a React Native project: this rule forbids JSX tags that don't begin with a capital letter",
+    },
+    messages: {
+      "forbid-lowercase-jsx-tags": 'JSX tags must begin with a capital letter; did you try to use an HTML tag in a React Native project?'
+    },
+    type: "problem",
+    schema: [],
+  },
+});
+
+export default rule;

--- a/tests/forbid-lowercase-jsx-tags.spec.ts
+++ b/tests/forbid-lowercase-jsx-tags.spec.ts
@@ -1,0 +1,52 @@
+import { ESLintUtils } from "@typescript-eslint/utils";
+import { rule } from "../lib/rules/forbid-lowercase-jsx-tags";
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    }
+  }
+});
+
+ruleTester.run("{RULE_NAME}", rule, {
+  valid: [
+    `
+    const Component = () => {
+      return <View><Text>Bonjour !</Text></View>;
+    }
+    `,
+    `
+    const Component = () => {
+      return <View />;
+    }
+    `,
+  ],
+  invalid: [
+    {
+      code: `
+      const Component = () => {
+        return <Svg><path d="M17 11H9.41l3.3-3.29a1.004 1.004" /></Svg>;
+      }
+      `,
+      errors: [{ messageId: "forbid-lowercase-jsx-tags" }],
+    },
+    {
+      code: `
+      const Component = () => {
+        return <div><p>Bonjour !</p></div>;
+      }
+      `,
+      errors: [{ messageId: "forbid-lowercase-jsx-tags" }, { messageId: "forbid-lowercase-jsx-tags" }],
+    },
+    {
+      code: `
+      const Component = () => {
+        return <div />;
+      }
+      `,
+      errors: [{ messageId: "forbid-lowercase-jsx-tags" }],
+    }
+  ],
+});


### PR DESCRIPTION
## 🔎 Description

> One sentence - explain the bad practice you want to kill with a new rule

Forbid lower case in JSX tags 
---

## 🧪 Code samples :

Wrong code samples :

```
<Svg><path d=""/></Svg>
```

Good code samples :

```
<Svg><Path d=""/></Svg>
```

---

## 📜 To do before asking for reviews

- [x] This rule does not exist in standard eslint plugins
- [x] I have added a test to prove my rule works
- [x] I have added the rule to the readme file
- [x] The CI checks all passed

---

## 🖼 Screenshots

[Screenshot to show the resulting warnings]
We did not manage to see the warnings
---

## 📣 When merging !

Please inform everyone to upgrade the hokla eslint plugin to benefit from your piece !
https://hokla.slack.com/archives/C02CZUN4QUW
Tell them to run `yarn upgrade @hokla/eslint-plugin-custom-rules` or `npm update @hokla/eslint-plugin-custom-rules`
