### PR TITLE
Add no-key-or-ref-prop rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# IDEA config folder
+.idea/

--- a/README.md
+++ b/README.md
@@ -41,14 +41,16 @@ In your `.eslintrc.json` file :
 ## List of supported rules
 
 | Rule                                    | Configuration | Description                                                                   |
-| --------------------------------------- | ------------- | ----------------------------------------------------------------------------- |
+|-----------------------------------------|---------------|-------------------------------------------------------------------------------|
 | typeorm-query-runner-release            | recommended   | Ensure all queryRunner instances finally release their db connection          |
 | react-query-specify-type                | recommended   | Force to specify data types when using methods useQuery and useMutation       |
 | property-decorator-type-mismatch        | recommended   | Ensure attribute decorator @Type(...) is consistent with property type        |
 | mutation-decorator-return-type-mismatch | recommended   | Ensure GraphQL @Mutation(...) decorator is consistent with method return type |
 | no-async-in-foreach                     | recommended   | Ensure that we don't use async callbacks in foreach loops                     |
 | redux-saga-no-sequential-actions        | recommended   | Prevent dispatching Redux Saga actions sequentially                           |
-| forbid-lower-case-jsx-tags          | recommended   | Ensure all JSX tags are not in lower case          |
+| forbid-lower-case-jsx-tags              | recommended   | Ensure all JSX tags are not in lower case                                     |
+| no-key-or-ref-prop                      | recommended   | Prevent naming function component props `key` or `ref`                        |
+
 # Contribute
 
 - Create a new branch and PR: https://github.com/hokla-org/eslint-plugin-custom-rules/compare

--- a/lib/rules/no-key-or-ref-prop.ts
+++ b/lib/rules/no-key-or-ref-prop.ts
@@ -1,0 +1,106 @@
+import {
+  AST_NODE_TYPES,
+  ESLintUtils,
+  TSESTree,
+} from '@typescript-eslint/utils';
+
+type MessageIds = 'no-key-or-ref-prop';
+
+type Options = [];
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) => `https://hokla.com/rule/${name}`
+);
+
+// Trying to follow example from this blog :
+// https://ryankubik.com/blog/eslint-internal-state#Building-More-Complex-ESLint-Rules
+// https://astexplorer.net/#/gist/1ff99fca3f85c2e7676ac041a88d7b53/179cf88e3a77c133741d9f96f0dc982b9f11ce4d
+
+type NodeWithBody = TSESTree.Node & {
+  body: TSESTree.BlockStatement;
+};
+
+const isTsPropertySignature = (node: TSESTree.Node | undefined): node is TSESTree.TSPropertySignature => {
+  return node !== undefined && node.type === 'TSPropertySignature';
+}
+
+const isTsInterfaceBody = (node: TSESTree.Node | undefined): node is TSESTree.TSInterfaceBody => {
+  return node !== undefined && node.type === 'TSInterfaceBody';
+}
+
+const isTsInterfaceDeclaration = (node: TSESTree.Node | undefined): node is TSESTree.TSInterfaceDeclaration => {
+  return node !== undefined && node.type === 'TSInterfaceDeclaration';
+}
+
+const isTsTypeLiteral = (node: TSESTree.Node | undefined): node is TSESTree.TSTypeLiteral => {
+  return node !== undefined && node.type === 'TSTypeLiteral';
+}
+
+const isTsTypeAliasDeclaration = (node: TSESTree.Node | undefined): node is TSESTree.TSTypeAliasDeclaration => {
+  return node !== undefined && node.type === 'TSTypeAliasDeclaration';
+}
+
+export const rule = createRule<Options, MessageIds>({
+  name: 'no-key-or-ref-prop',
+  defaultOptions: [],
+  create(context) {
+    return {
+      ["TSInterfaceDeclaration > TSInterfaceBody > TSPropertySignature > :matches(Identifier[name='ref'], Identifier[name='key'])"](
+        node: TSESTree.Identifier
+      ) {
+        const propertySignature = node.parent;
+        if (!isTsPropertySignature(propertySignature)) return;
+
+        const interfaceBody = propertySignature.parent;
+        if (!isTsInterfaceBody(interfaceBody)) return;
+
+        const interfaceDeclaration = interfaceBody.parent;
+        if (!isTsInterfaceDeclaration(interfaceDeclaration)) return;
+
+        const identifier: TSESTree.Identifier = interfaceDeclaration.id;
+
+        if (identifier.name.endsWith('Props')) {
+          return context.report({
+            messageId: 'no-key-or-ref-prop',
+            node: node,
+          });
+        }
+      },
+      ["TSTypeAliasDeclaration > TSTypeLiteral > TSPropertySignature > :matches(Identifier[name='ref'], Identifier[name='key'])"](
+        node: TSESTree.Identifier
+      ) {
+        const propertySignature = node.parent;
+        if (!isTsPropertySignature(propertySignature)) return;
+
+        const typeLiteral = propertySignature.parent;
+        if (!isTsTypeLiteral(typeLiteral)) return;
+
+        const typeAliasDeclaration = typeLiteral.parent;
+        if (!isTsTypeAliasDeclaration(typeAliasDeclaration)) return;
+
+        const identifier: TSESTree.Identifier = typeAliasDeclaration.id;
+
+        if (identifier.name.endsWith('Props')) {
+          return context.report({
+            messageId: 'no-key-or-ref-prop',
+            node: node,
+          });
+        }
+      },
+    };
+  },
+  meta: {
+    docs: {
+      recommended: 'error',
+      description:
+        'This rule forbids using props named `key` or `ref` in React function components, as they are reserved words and will not act as intended',
+    },
+    messages: {
+      'no-key-or-ref-prop': "Do not use `key` or `ref` as prop names, as they won't work expectedly with React; rename them to something else or use forwardRef() instead."
+    },
+    type: 'problem',
+    schema: [],
+  },
+});
+
+export default rule;

--- a/tests/no-key-or-ref-prop.spec.ts
+++ b/tests/no-key-or-ref-prop.spec.ts
@@ -1,0 +1,73 @@
+import { ESLintUtils } from "@typescript-eslint/utils";
+import { rule } from "../lib/rules/no-key-or-ref-prop";
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parser: "@typescript-eslint/parser",
+});
+
+ruleTester.run("{RULE_NAME}", rule, {
+  valid: [
+    `
+    interface MyComponentProps {
+      thisIsNotRef: any;
+      thisIsNotKey: any;
+    }
+    `,
+    `
+    type MyComponentProps = {
+      thisIsNotRef: any;
+      thisIsNotKey: any;
+    };
+    `,
+    `
+    interface ItLooksLikePropsButIsNot {
+      ref: any;
+      key: any;
+    }
+    `,
+    `
+    type ItLooksLikePropsButIsNot = {
+      ref: any;
+      key: any;
+    };
+    `
+  ],
+  invalid: [
+    {
+      code: `
+      interface MyComponentProps {
+        ref: any;
+        otherProp: any;
+      }
+      `,
+      errors: [{ messageId: "no-key-or-ref-prop" }],
+    },
+    {
+      code: `
+      interface MyComponentProps {
+        key: any;
+        otherProp: any;
+      }
+      `,
+      errors: [{ messageId: "no-key-or-ref-prop" }],
+    },
+    {
+      code: `
+      type MyComponentProps = {
+        ref: any;
+        otherProp: any;
+      };
+      `,
+      errors: [{ messageId: "no-key-or-ref-prop" }],
+    },
+    {
+      code: `
+      type MyComponentProps = {
+        key: any;
+        otherProp: any;
+      };
+      `,
+      errors: [{ messageId: "no-key-or-ref-prop" }],
+    },
+  ],
+});


### PR DESCRIPTION
## 🔎 Description

> Props named `ref` or `key` do not work correctly with React (see [here](https://react.dev/warnings/special-props) why). With this rule, we forbid them and recommend another name or the use of [`forwardRef`](https://react.dev/reference/react/forwardRef).

---

## 🧪 Code samples :

Wrong code samples :

```
interface MyComponentProps {
  ref: any;
  key: any;
}

type MyComponentProps = {
  ref: any;
  key: any;
};
```

Good code samples :

```
interface MyComponentProps {
  myRef: any;
  myKey: any;
}

type MyComponentProps = {
  myRef: any;
  myKey: any;
};
```

OR (better):

```
const Component = forwardRef<RefType, MyComponentProps>((props, ref) => <…>);
```

---

## 📜 To do before asking for reviews

- [x] This rule does not exist in standard eslint plugins => AFAIK, I have searched a bit
- [x] I have added a test to prove my rule works
- [x] I have added the rule to the readme file
- [x] The CI checks all passed

---

## 🖼 Screenshots

<img width="1005" alt="image" src="https://user-images.githubusercontent.com/6844183/226933465-c8050ffe-19c1-486f-8dff-84464216e577.png">

---

## 📣 When merging !

Please inform everyone to upgrade the hokla eslint plugin to benefit from your piece !
https://hokla.slack.com/archives/C02CZUN4QUW
Tell them to run `yarn upgrade @hokla/eslint-plugin-custom-rules` or `npm update @hokla/eslint-plugin-custom-rules`
