### PR TITLE
feat: 30 Create a npm script to generate a new rule boilerplate

### DIFF
--- a/generate/generateNewRule.ts
+++ b/generate/generateNewRule.ts
@@ -1,0 +1,30 @@
+import *  as  fs from 'fs';
+import * as readline from 'readline';
+import * as path from 'path';
+
+const RULE_BOILERPLATE_FILE = 'rule.boilerplate.ts';
+const RULE_TESTS_BOILERPLATE_FILE = 'ruleTests.boilerplate.ts';
+
+const SCRIPT_DIR = path.dirname(process.argv[1]);
+process.chdir(SCRIPT_DIR);
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout
+});
+
+rl.question("Choose a rule name (separated by dashes): ", (ruleName : string) => {
+  const ruleBoilerplate = fs.readFileSync(RULE_BOILERPLATE_FILE, 'utf-8');
+  const ruleFileContent = ruleBoilerplate.replace(/RULE_NAME_PLACEHOLDER/g, ruleName);
+  const ruleFilePath = path.join('..', 'lib', 'rules', `${ruleName}.ts`);
+  fs.writeFileSync(ruleFilePath, ruleFileContent);
+
+  const ruleTestsTemplate = fs.readFileSync(RULE_TESTS_BOILERPLATE_FILE, 'utf-8');
+  const ruleTestsFileContent = ruleTestsTemplate.replace(/RULE_NAME_PLACEHOLDER/g, ruleName);
+  const ruleTestsFilePath = path.join('..', 'tests', 'rules', `${ruleName}.spec.ts`);
+  fs.writeFileSync(ruleTestsFilePath, ruleTestsFileContent);
+
+
+
+  rl.close();
+});

--- a/generate/rule.boilerplate.ts
+++ b/generate/rule.boilerplate.ts
@@ -1,0 +1,42 @@
+import {
+  ESLintUtils,
+  TSESTree,
+} from "@typescript-eslint/utils";
+
+type MessageIds = "RULE_NAME_PLACEHOLDER";
+
+type Options = [];
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) => `https://hokla.com/rule/${name}`
+);
+
+const rule = createRule<Options, MessageIds>({
+  name: "RULE_NAME_PLACEHOLDER",
+  defaultOptions: [],
+  create(context) {
+    return {
+      // Select a node from the AST
+      ["TODO"](node: TSESTree.JSXIdentifier) {  
+          return context.report({
+            messageId: "RULE_NAME_PLACEHOLDER",
+            node: node,
+          });
+      },
+    };
+  },
+  meta: {
+    docs: {
+      recommended: "error",
+      description: "TODO"
+    },
+    messages: {
+      "RULE_NAME_PLACEHOLDER":
+        "TODO",
+    },
+    type: "problem",
+    schema: [],
+  },
+});
+
+export default {...rule, configs: ["TODO"]}

--- a/generate/ruleTests.boilerplate.ts
+++ b/generate/ruleTests.boilerplate.ts
@@ -1,0 +1,23 @@
+import { ESLintUtils } from "@typescript-eslint/utils";
+import rule from "../../lib/rules/RULE_NAME_PLACEHOLDER";
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parser: "@typescript-eslint/parser",
+});
+
+ruleTester.run("{RULE_NAME}", rule, {
+  valid: [
+    `
+    TODO
+    `
+  ],
+  invalid: [
+    {
+      code: `
+      TODO
+      `,
+      errors: [{ messageId: "RULE_NAME_PLACEHOLDER" }],
+    },
+  ],
+});
+

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "typecheck": "tsc --noEmit",
     "check:eslint-docs": "eslint-doc-generator --check",
     "create:eslint-docs": "eslint-doc-generator --init-rule-docs",
-    "update:eslint-docs": "eslint-doc-generator"
+    "update:eslint-docs": "eslint-doc-generator",
+    "rule:generate": "yarn ts-node generate/generateNewRule.ts && yarn build && yarn create:eslint-docs"
   },
   "directories": {
     "lib": "lib",


### PR DESCRIPTION
Adds a new command "yarn generate" that generate :
- A rule file boilerplate
- A test file boilerplate
- A doc file boilerplate

🎯 *Issue* https://github.com/hokla-org/eslint-plugin-custom-rules/issues/30 

## 📣 When merging !

Please inform everyone to upgrade the hokla eslint plugin to benefit from your piece !
https://hokla.slack.com/archives/C02CZUN4QUW
Tell them to run `yarn upgrade @hokla/eslint-plugin-custom-rules` or `npm update @hokla/eslint-plugin-custom-rules`
